### PR TITLE
Add ClusterRole and ClusterRoleBinding

### DIFF
--- a/ztp/gitops-subscriptions/argocd/binding.yaml
+++ b/ztp/gitops-subscriptions/argocd/binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: converter
+  namespace: clusters-sub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ran-pipeline
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: clusters-sub

--- a/ztp/gitops-subscriptions/argocd/clusterrole.yaml
+++ b/ztp/gitops-subscriptions/argocd/clusterrole.yaml
@@ -1,0 +1,144 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ran-pipeline
+rules:
+# Read Site resources
+- apiGroups:
+  - ran.openshift.io
+  resources:
+  - siteconfigs
+  verbs:
+  - get
+  - watch
+  - list
+  # For debug
+  - create
+  - delete
+  - patch
+  - update
+
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+
+- apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - infraenvs
+  - nmstateconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+
+- apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+
+- apiGroups:
+  - metal3.io
+  resources:
+  - baremetalhosts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+- apiGroups:
+  - agent.open-cluster-management.io
+  resources:
+  - klusterletaddonconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  - managedclustersets
+  - managedclustersets/join
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+
+
+- apiGroups:
+  - register.open-cluster-management.io
+  resources:
+  - managedclusters/accept
+  verbs:
+  - update
+


### PR DESCRIPTION
The ClusterRole gives sufficient permissions for the container used in
the post-job to create the installation CRs and apply them to the
cluster.

Signed-off-by: Ian Miller <imiller@redhat.com>